### PR TITLE
New exceptions for Berlin A fare zone

### DIFF
--- a/exceptions.js
+++ b/exceptions.js
@@ -3,6 +3,8 @@
 module.exports = {
 	insideA: [
 		'900000026202' // U Kaiserdamm
+		'900000160003' // S Nöldnerplatz (Berlin)
+		'900000160004' // S+U Lichtenberg Bhf (Berlin)
 	],
 	insideB: [
 		'900000175010' // U Hönow


### PR DESCRIPTION
S-Bahn stations "Nöldnerplatz" and "Lichtenberg" are also accessible with a ticket valid for VBB Berlin A zone (e. g. DB BahnCard 100)

"DB-Fahrkarten mit dem Aufdruck „Berlin+City“ sowie die BahnCard 100 berechtigen zur Nutzung der Verkehrsmittel im Teilbereich A des Tarifbereiches Berlin. Sie gelten auch bis zu den Bahnhöfen Nöldnerplatz und Berlin-Lichtenberg."

https://sbahn.berlin/fileadmin/user_upload/Tickets/Tarifgebiet_Berlin-Brandenburg/Tarifbroschueren/Flyer_VBB-Tarif.pdf - page 73